### PR TITLE
Update FileManager.php

### DIFF
--- a/src/FileManager.php
+++ b/src/FileManager.php
@@ -139,7 +139,7 @@ class FileManager extends Field implements InteractsWithFilesystem
 
         if (is_array($value)) {
             if ($this->multiple) {
-                $value = collect($value)->map(fn (array $asset) => new Asset(...$asset));
+                $value = collect($value)->map(fn (array|object $asset) => new Asset(... (array) $asset));
             } else {
                 $value = collect([new Asset(...$value)]);
             }


### PR DESCRIPTION
When the DB column being written to is cast as an object and the FileManager field is assigned as multuple, after saving the model and subsequently trying to access it again I encounter the error "Argument #1 ($asset) must be of type array, stdClass given"

This change adjusts line 142 to allow for the field value to be passed in as an object, then converted to an array and unpacked into a new Asset as usual.