### PR TITLE
Return string representation of Asset

### DIFF
--- a/src/Support/Asset.php
+++ b/src/Support/Asset.php
@@ -53,6 +53,6 @@ class Asset implements Arrayable, JsonSerializable
     
     public function __toString(): string
     {
-        return return json_encode($this, JSON_THROW_ON_ERROR);
+        return return json_encode($this->jsonSerialize(), JSON_THROW_ON_ERROR);
     }
 }

--- a/src/Support/Asset.php
+++ b/src/Support/Asset.php
@@ -53,6 +53,6 @@ class Asset implements Arrayable, JsonSerializable
     
     public function __toString(): string
     {
-        return return json_encode($this->jsonSerialize(), JSON_THROW_ON_ERROR);
+        return json_encode($this->jsonSerialize(), JSON_THROW_ON_ERROR);
     }
 }

--- a/src/Support/Asset.php
+++ b/src/Support/Asset.php
@@ -50,4 +50,9 @@ class Asset implements Arrayable, JsonSerializable
     {
         return $this->toArray();
     }
+    
+    public function __toString(): string
+    {
+        return return json_encode($this, JSON_THROW_ON_ERROR);
+    }
 }


### PR DESCRIPTION
Fix compatibility with third-party packages (e.g. [Nova Settings](https://github.com/outl1ne/nova-settings))

This will work around the following error and allow the asset to be JsonSerialized properly.

`Oneduo/NovaFileManager\Support\Asset could not be converted to string`