### PR TITLE
Add support for nova-settings

### DIFF
--- a/src/Http/Requests/BaseRequest.php
+++ b/src/Http/Requests/BaseRequest.php
@@ -52,7 +52,7 @@ class BaseRequest extends NovaRequest
     protected function resolveFieldFromNovaSettingsResource()
     {
         // Retrieve the NovaSettings tool fields
-        if (class_exists($novaSettingsClass = 'Outl1ne\NovaSettings\NovaSettinsgs')) {
+        if (class_exists($novaSettingsClass = 'Outl1ne\NovaSettings\NovaSettings')) {
             $fields = $novaSettingsClass::getFields();
         } else {
             throw ValidationException::withMessages([


### PR DESCRIPTION
This will add support for [Nova Settings](https://github.com/outl1ne/nova-settings) package.

Previously if you register a FileManager field within a Nova Settings resource a 404 error would be thrown as described in this issue #124.

This will add compatibility with Nova Settings and would also play nice with panels or [callable registered fields](https://github.com/outl1ne/nova-settings) that allow you to extract fields to invokable classes.
