### PR TITLE
Fix hidden files within folders

### DIFF
--- a/src/Services/FileManagerService.php
+++ b/src/Services/FileManagerService.php
@@ -152,7 +152,7 @@ class FileManagerService implements FileManagerContract, ResolvesUrlContract
     {
         $this->filterCallbacks[] = $this->shouldShowHiddenFiles
             ? static fn () => true
-            : static fn (string $path) => !str($path)->startsWith('.');
+            : static fn (string $path) => !str($path)->afterLast('/')->startsWith('.');
     }
 
     /**


### PR DESCRIPTION
This will fix a bug where FileManager would not respect `show_hidden_files` set to `false` inside sub-folders.