### PR TITLE
Fix preview error on detail field after closing browser

### DIFF
--- a/resources/js/hooks/usePermissions.js
+++ b/resources/js/hooks/usePermissions.js
@@ -4,14 +4,14 @@ import { computed } from 'vue'
 export function usePermissions() {
   const store = useStore()
 
-  const showCreateFolder = computed(() => store.permissions.folder.create)
-  const showRenameFolder = computed(() => store.permissions.folder.rename)
-  const showDeleteFolder = computed(() => store.permissions.folder.delete)
-  const showUploadFile = computed(() => store.permissions.file.upload)
-  const showRenameFile = computed(() => store.permissions.file.rename)
-  const showDeleteFile = computed(() => store.permissions.file.delete)
-  const showCropImage = computed(() => store.permissions.file.edit)
-  const showUnzipFile = computed(() => store.permissions.file.unzip)
+  const showCreateFolder = computed(() => store.permissions?.folder?.create)
+  const showRenameFolder = computed(() => store.permissions?.folder?.rename)
+  const showDeleteFolder = computed(() => store.permissions?.folder?.delete)
+  const showUploadFile = computed(() => store.permissions?.file?.upload)
+  const showRenameFile = computed(() => store.permissions?.file?.rename)
+  const showDeleteFile = computed(() => store.permissions?.file?.delete)
+  const showCropImage = computed(() => store.permissions?.file?.edit)
+  const showUnzipFile = computed(() => store.permissions?.file?.unzip)
 
   return {
     showCreateFolder,


### PR DESCRIPTION
This PR will fix a bug where previewing an image on detail view after the browser was closed would throw a console error and freeze.
`TypeError: Cannot read properties of null (reading 'file')`

To reproduce:
1. On a resource with an existing image click "Choose Image" to open the browser
2. Close the browser
3. Return back to the resource detail view by clicking cancel or update.
4. Click on the image

Instead of the preview modal an error would be thrown because permissions have been reset by the tool.
If you hard refresh the page, you can preview again normally.

Demonstration:

https://user-images.githubusercontent.com/6439071/214652861-53dab340-af60-4286-8088-9cc84c61d385.mov

