### PR TITLE
Implement Cover on field to allow for thumbnails

### DIFF
--- a/src/FileManager.php
+++ b/src/FileManager.php
@@ -53,9 +53,17 @@ class FileManager extends Field implements InteractsWithFilesystemContract, Cove
 
     public function resolveThumbnailUrl()
     {
+        if (data_get($this->value, '0.type') !== 'image') {
+            return null;
+        }
+        
+        if ($this->hasUrlResolver()){
+            return data_get($this->value, '0.url');
+        }
+        
         $value = data_get($this->value, '0.path');
         $disk = data_get($this->value, '0.disk') ?? config('nova.storage_disk');
-
+        
         return is_callable($this->thumbnailUrlCallback)
                     ? call_user_func($this->thumbnailUrlCallback, $value, $disk, $this->resource)
                     : null;


### PR DESCRIPTION
This will enable thumbnails on global search and searchable relations for resources containing a `FileManager` field.

![pr](https://user-images.githubusercontent.com/6439071/217310401-60b414aa-7ffb-49ec-b327-cae562253138.png)
