### PR TITLE
Fix: UploadQueueModal over box in Safari

### DIFF
--- a/resources/js/components/Modals/UploadQueueModal.vue
+++ b/resources/js/components/Modals/UploadQueueModal.vue
@@ -26,7 +26,7 @@ const queue = computed(() => store.queue)
         <div class="w-full flex flex-row justify-between items-center">
           <h1 class="text-xs uppercase text-gray-400 font-bold">Queue</h1>
         </div>
-        <ul class="grid grid-cols-2 md:grid-cols-4 gap-6">
+        <ul class="grid grid-cols-2 md:grid-cols-4 content-start gap-6">
           <template v-for="item in queue" :key="item.id">
             <File
               :file="nativeFileToEntity(item.file)"


### PR DESCRIPTION
This bug fix aims to address the interface breakage issue of the upload queue box on Safari.

Before the fix:
![Zalo_ScreenShot_6_7_2023_117476](https://github.com/oneduo/nova-file-manager/assets/18624860/0d4cbc45-e45d-40d0-b63f-ddd5549b12db)

After the fix:
![Zalo_ScreenShot_6_7_2023_118100](https://github.com/oneduo/nova-file-manager/assets/18624860/3de494a3-3222-4fb6-8c4b-f80d8babdacd)
