### PR TITLE
Proposed support for changing pathways to meet business needs.

### DIFF
--- a/config/nova-file-manager.php
+++ b/config/nova-file-manager.php
@@ -163,4 +163,16 @@ return [
     |
     */
     'use_pintura' => env('NOVA_FILE_MANAGER_USE_PINTURA', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | File Manager Path
+    |--------------------------------------------------------------------------
+    |
+    | This is the URI path where File Manager will be accessible from.
+    | Feel free to change this path to anything you like.
+    |
+    */
+
+    'path' => '/nova-file-manager',
 ];

--- a/src/NovaFileManager.php
+++ b/src/NovaFileManager.php
@@ -16,7 +16,7 @@ class NovaFileManager extends Tool implements InteractsWithFilesystem
     public function menu(Request $request): mixed
     {
         return MenuSection::make('File Manager')
-            ->path('/nova-file-manager')
+            ->path(config('nova-file-manager.path', '/nova-file-manager'))
             ->icon('server');
     }
 }

--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -43,8 +43,10 @@ class ToolServiceProvider extends ServiceProvider
             return;
         }
 
-        Nova::router(['nova', Authenticate::class, Authorize::class], 'nova-file-manager')
-            ->group(__DIR__ . '/../routes/inertia.php');
+        Nova::router(
+            ['nova', Authenticate::class, Authorize::class],
+            config('nova-file-manager.path', '/nova-file-manager')
+        )->group(__DIR__ . '/../routes/inertia.php');
 
         Route::middleware(['nova:api', Authorize::class])
             ->prefix('nova-vendor/nova-file-manager')


### PR DESCRIPTION
Dear owner,

Depending on the project requirements, developers may need to change the default access path from '/nova-file-laravel' to a desired path. Therefore, I suggest supporting the custom of this parameter in the configuration file.

Reference from PR #265 