### PR TITLE
Fix the error "FileManagerContract::expect() does not exist on this mock object."

### DIFF
--- a/tests/Feature/Directory/DirectoryTest.php
+++ b/tests/Feature/Directory/DirectoryTest.php
@@ -56,11 +56,10 @@ it('can create a directory', function () {
 it('throws an exception if the filesystem cannot create the directory', function () {
     Event::fake();
 
-    $mock = mock(FileManagerContract::class)->expect(
-        mkdir: fn ($path) => false,
-        filesystem: fn () => Storage::disk($this->disk),
-        getDisk: fn () => $this->disk,
-    );
+    $mock = Mockery::mock(FileManagerContract::class);
+    $mock->shouldReceive('mkdir')->andReturn(false);
+    $mock->shouldReceive('filesystem')->andReturn(Storage::disk($this->disk));
+    $mock->shouldReceive('getDisk')->andReturn($this->disk);
 
     app()->instance(FileManagerContract::class, $mock);
 
@@ -159,11 +158,10 @@ it('can rename a directory', function () {
 it('returns validation error when the filesystem can not rename the directory', function () {
     Event::fake();
 
-    $mock = mock(FileManagerContract::class)->expect(
-        rename: fn ($path) => false,
-        filesystem: fn () => Storage::disk($this->disk),
-        getDisk: fn () => $this->disk,
-    );
+    $mock = Mockery::mock(FileManagerContract::class);
+    $mock->shouldReceive('rename')->andReturn(false);
+    $mock->shouldReceive('filesystem')->andReturn(Storage::disk($this->disk));
+    $mock->shouldReceive('getDisk')->andReturn($this->disk);
 
     app()->instance(FileManagerContract::class, $mock);
 
@@ -323,11 +321,10 @@ it('cannot delete a directory which doesnt exist', function () {
 it('throws an exception if the filesystem cannot delete the directory', function () {
     Event::fake();
 
-    $mock = mock(FileManagerContract::class)->expect(
-        rmdir: fn ($path) => false,
-        filesystem: fn () => Storage::disk($this->disk),
-        getDisk: fn () => $this->disk,
-    );
+    $mock = Mockery::mock(FileManagerContract::class);
+    $mock->shouldReceive('rmdir')->andReturn(false);
+    $mock->shouldReceive('filesystem')->andReturn(Storage::disk($this->disk));
+    $mock->shouldReceive('getDisk')->andReturn($this->disk);
 
     app()->instance(FileManagerContract::class, $mock);
 

--- a/tests/Feature/File/FileTest.php
+++ b/tests/Feature/File/FileTest.php
@@ -249,11 +249,10 @@ it('cannot rename a file to an existing name', function () {
 it('throws an exception if the filesystem cannot rename the file', function () {
     Event::fake();
 
-    $mock = mock(FileManagerContract::class)->expect(
-        rename: fn (string $from, string $to) => false,
-        filesystem: fn () => Storage::disk($this->disk),
-        getDisk: fn () => $this->disk,
-    );
+    $mock = Mockery::mock(FileManagerContract::class);
+    $mock->shouldReceive('rename')->andReturn(false);
+    $mock->shouldReceive('filesystem')->andReturn(Storage::disk($this->disk));
+    $mock->shouldReceive('getDisk')->andReturn($this->disk);
 
     app()->instance(FileManagerContract::class, $mock);
 
@@ -373,11 +372,10 @@ it('cant delete a non existing file', function () {
 it('throws an exception if the filesystem cannot delete the file', function () {
     Event::fake();
 
-    $mock = mock(FileManagerContract::class)->expect(
-        delete: fn (string $path) => false,
-        filesystem: fn () => Storage::disk($this->disk),
-        getDisk: fn () => $this->disk,
-    );
+    $mock = Mockery::mock(FileManagerContract::class);
+    $mock->shouldReceive('delete')->andReturn(false);
+    $mock->shouldReceive('filesystem')->andReturn(Storage::disk($this->disk));
+    $mock->shouldReceive('getDisk')->andReturn($this->disk);
 
     app()->instance(FileManagerContract::class, $mock);
 
@@ -463,11 +461,10 @@ it('can unzip an archive', function () {
 it('throws an exception if the filesystem cannot unzip the archive', function () {
     Event::fake();
 
-    $mock = mock(FileManagerContract::class)->expect(
-        unzip: fn (string $path) => false,
-        filesystem: fn () => Storage::disk($this->disk),
-        getDisk: fn () => $this->disk,
-    );
+    $mock = Mockery::mock(FileManagerContract::class);
+    $mock->shouldReceive('unzip')->andReturn(false);
+    $mock->shouldReceive('filesystem')->andReturn(Storage::disk($this->disk));
+    $mock->shouldReceive('getDisk')->andReturn($this->disk);
 
     app()->instance(FileManagerContract::class, $mock);
 


### PR DESCRIPTION
Dear owner,

I have a fix for the error "Method Mockery_2_Oneduo_NovaFileManager_Contracts_Services_FileManagerContract::expect() does not exist on this mock object." in testcase.

Reference from PR #265 

![6_case_errors](https://github.com/oneduo/nova-file-manager/assets/18624860/2791fc33-bd85-4e79-952e-982eaf10145f)
[logs_39.zip](https://github.com/oneduo/nova-file-manager/files/11997034/logs_39.zip)

