### PR TITLE
Allow upload to replace file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,9 +44,9 @@
     "mockery/mockery": "^1.5",
     "orchestra/testbench": "^6.0 || ^7.6 || ^8.0",
     "orchestra/testbench-dusk": "^6.0 || ^7.6 || ^8.0",
-    "pestphp/pest": "^2.0",
-    "pestphp/pest-plugin-laravel": "^2.0",
-    "pestphp/pest-plugin-mock": "^2.0",
+    "pestphp/pest": "^1.21 || ^2.0",
+    "pestphp/pest-plugin-laravel": "^1.2 || ^2.0",
+    "pestphp/pest-plugin-mock": "^1.0 || ^2.0",
     "spatie/laravel-ray": "^1.29"
   },
   "autoload": {

--- a/config/nova-file-manager.php
+++ b/config/nova-file-manager.php
@@ -44,7 +44,7 @@ return [
     |
     | default: false
     */
-    'show_hidden_files' => env('NOVA_FILE_MANAGER_SHOW_HIDDEN_FILES', false),
+    'show_hidden_files' => (bool) env('NOVA_FILE_MANAGER_SHOW_HIDDEN_FILES', false),
 
     /*
     |--------------------------------------------------------------------------
@@ -56,7 +56,7 @@ return [
     |
     | default: true
     */
-    'human_readable_size' => env('NOVA_FILE_MANAGER_HUMAN_READABLE_SIZE', true),
+    'human_readable_size' => (bool) env('NOVA_FILE_MANAGER_HUMAN_READABLE_SIZE', true),
 
     /*
     |--------------------------------------------------------------------------
@@ -68,7 +68,7 @@ return [
     |
     | default: true
     */
-    'human_readable_datetime' => env('NOVA_FILE_MANAGER_HUMAN_READABLE_DATETIME', true),
+    'human_readable_datetime' => (bool) env('NOVA_FILE_MANAGER_HUMAN_READABLE_DATETIME', true),
 
     /*
     |--------------------------------------------------------------------------
@@ -83,9 +83,9 @@ return [
     */
 
     'file_analysis' => [
-        'enabled' => env('NOVA_FILE_MANAGER_FILE_ANALYSIS_ENABLED', true),
+        'enabled' => (bool) env('NOVA_FILE_MANAGER_FILE_ANALYSIS_ENABLED', true),
         'cache' => [
-            'enabled' => env('NOVA_FILE_MANAGER_FILE_ANALYSIS_CACHE_ENABLED', true),
+            'enabled' => (bool) env('NOVA_FILE_MANAGER_FILE_ANALYSIS_CACHE_ENABLED', true),
             'ttl_in_seconds' => env('NOVA_FILE_MANAGER_FILE_ANALYSIS_CACHE_TTL_IN_SECONDS', 60 * 60 * 24),
         ],
     ],
@@ -119,7 +119,7 @@ return [
     | Uses: Storage::temporaryUrl()
     */
     'url_signing' => [
-        'enabled' => env('NOVA_FILE_MANAGER_URL_SIGNING_ENABLED', false),
+        'enabled' => (bool) env('NOVA_FILE_MANAGER_URL_SIGNING_ENABLED', false),
         'unit' => 'minutes',
         'value' => 10,
     ],
@@ -135,8 +135,8 @@ return [
     |
     */
     'update_checker' => [
-        'enabled' => env('NOVA_FILE_MANAGER_UPDATE_CHECKER_ENABLED', true),
-        'ttl_in_days' => env('NOVA_FILE_MANAGER_UPDATE_CHECKER_TTL_IN_DAYS', 1),
+        'enabled' => (bool) env('NOVA_FILE_MANAGER_UPDATE_CHECKER_ENABLED', true),
+        'ttl_in_days' => (int) env('NOVA_FILE_MANAGER_UPDATE_CHECKER_TTL_IN_DAYS', 1),
     ],
 
     /*
@@ -151,7 +151,7 @@ return [
     |
     */
     'tour' => [
-        'enabled' => env('NOVA_FILE_MANAGER_TOUR_ENABLED', true),
+        'enabled' => (bool) env('NOVA_FILE_MANAGER_TOUR_ENABLED', true),
     ],
 
     /*
@@ -162,7 +162,7 @@ return [
     | Enable Pintura editor by PQINA.
     |
     */
-    'use_pintura' => env('NOVA_FILE_MANAGER_USE_PINTURA', false),
+    'use_pintura' => (bool) env('NOVA_FILE_MANAGER_USE_PINTURA', false),
 
     /*
     |--------------------------------------------------------------------------
@@ -175,4 +175,17 @@ return [
     */
 
     'path' => '/nova-file-manager',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Upload replace existing
+    |--------------------------------------------------------------------------
+    |
+    | Toggle whether an upload with an existing file name should replace
+    | the existing file or not.
+    |
+    */
+
+    'upload_replace_existing' => (bool) env('NOVA_FILE_MANAGER_UPLOAD_REPLACE_EXISTING', false),
+
 ];

--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -245,3 +245,31 @@ class Project extends Resource
 }
 ```
 
+## Upload with an existing file name
+
+By default, when you upload a file at a path which already contains a file with the same name a validation error will be thrown. You may want the file to be replaced by the upload. You can change the configuration to always replace existing file in the [Configuration file](/configuration#upload-replace-existing). You can also do it programmatically by using the `uploadReplaceExisting` method on your tool, field or wrapper.
+
+```php
+// app/Nova/Project.php
+
+use Oneduo\NovaFileManager\FileManager;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Storage;
+use Laravel\Nova\Http\Requests\NovaRequest;
+
+class Project extends Resource
+{
+    // ...
+
+    public function fields(NovaRequest $request): array
+    {
+        return [
+            // ... any other fields
+            FileManager::make(__('Attachments'), 'attachments')
+                ->uploadReplaceExisting(function (NovaRequest $request): bool {
+                    return true;
+                }),
+        ];
+    }
+}
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -135,3 +135,21 @@ Toggles whether to show use Pintura image editor
 ::: tip NOTE
 You can find details about the Pintura integration in the [Pintura image editor section](/pintura).
 :::
+
+## `path`
+
+This is the URI path where File Manager will be accessible from
+
+| Type     | Default              |
+|----------|----------------------|
+| `string` | `/nova-file-manager` |
+
+
+## `upload_replace_existing`
+
+Toggle whether an upload with an existing file name should replace the existing file or not
+
+| Type   | Default |
+|--------|---------|
+| `bool` | `false` |
+

--- a/docs/tool.md
+++ b/docs/tool.md
@@ -36,6 +36,10 @@ If you are using a custom menu, you may want to add a new entry to it.
 MenuSection::make('File Manager')->path('/nova-file-manager')
 ```
 
+::: tip NOTE
+You can change the tool path in the [Configuration file](/configuration#path).
+:::
+
 ## Navigating in the tool
 
 <img src="./images/tool.png" alt="tool"/>

--- a/src/Contracts/Support/InteractsWithFilesystem.php
+++ b/src/Contracts/Support/InteractsWithFilesystem.php
@@ -67,6 +67,10 @@ interface InteractsWithFilesystem extends ResolvesUrl
 
     public function resolveCanUploadFile(NovaRequest $request): bool;
 
+    public function uploadReplaceExisting(Closure $callback): static;
+
+    public function resolveUploadReplaceExisting(NovaRequest $request): bool;
+
     public function canRenameFile(Closure $callback): static;
 
     public function resolveCanRenameFile(NovaRequest $request): bool;

--- a/src/Http/Requests/UploadFileRequest.php
+++ b/src/Http/Requests/UploadFileRequest.php
@@ -43,11 +43,19 @@ class UploadFileRequest extends BaseRequest
 
     public function rules(): array
     {
+        $uploadReplaceExisting = $this->element()->resolveUploadReplaceExisting($this);
+
+        $rules = ['required', 'file'];
+
+        if (!$uploadReplaceExisting) {
+            $rules[] = new FileMissingInFilesystem($this);
+        }
+
         return [
             'disk' => ['sometimes', 'string', new DiskExistsRule()],
             'path' => ['required', 'string'],
             'file' => array_merge(
-                ['required', 'file', new FileMissingInFilesystem($this)],
+                $rules,
                 $this->element()->getUploadRules(),
             ),
         ];

--- a/src/Traits/Support/InteractsWithFilesystem.php
+++ b/src/Traits/Support/InteractsWithFilesystem.php
@@ -24,6 +24,8 @@ trait InteractsWithFilesystem
 
     public ?Closure $canUploadFile = null;
 
+    public ?Closure $uploadReplaceExisting = null;
+
     public ?Closure $canRenameFile = null;
 
     public ?Closure $canDeleteFile = null;
@@ -239,6 +241,20 @@ trait InteractsWithFilesystem
         return is_callable($this->canUploadFile)
             ? call_user_func($this->canUploadFile, $request)
             : $this->shouldShowUploadFile($request);
+    }
+
+    public function uploadReplaceExisting(Closure $callback): static
+    {
+        $this->uploadReplaceExisting = $callback;
+
+        return $this;
+    }
+
+    public function resolveUploadReplaceExisting(NovaRequest $request): bool
+    {
+        return is_callable($this->uploadReplaceExisting)
+            ? call_user_func($this->uploadReplaceExisting, $request)
+            : config('nova-file-manager.upload_replace_existing', false);
     }
 
     public function canRenameFile(Closure $callback): static


### PR DESCRIPTION
This PR adds ability to replace file when uploading a file with an existing file name.

It adds a configuration option `upload_replace_existing`, when set to true it allows upload to replace existing file.

It also adds the new `uploadReplaceExisting` method on field, tool and wrapper to configure it programmatically

```php
// app/Nova/Project.php

use Oneduo\NovaFileManager\FileManager;
use Illuminate\Contracts\Filesystem\Filesystem;
use Illuminate\Support\Facades\Storage;
use Laravel\Nova\Http\Requests\NovaRequest;

class Project extends Resource
{
    // ...

    public function fields(NovaRequest $request): array
    {
        return [
            // ... any other fields
            FileManager::make(__('Attachments'), 'attachments')
                ->uploadReplaceExisting(function (NovaRequest $request): bool {
                    return true;
                }),
        ];
    }
}
```

Closes [#268 ](https://github.com/oneduo/nova-file-manager/issues/238)