### PR TITLE
Allow spatie/invade:^1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "laravel/nova": "^4.0",
     "nova-kit/nova-packages-tool": "^1.3.1",
     "pion/laravel-chunk-upload": "^1.5",
-    "spatie/invade": "^2.0"
+    "spatie/invade": "^1.0 || ^2.0"
   },
   "require-dev": {
     "guzzlehttp/guzzle": "^7.0.1",


### PR DESCRIPTION
Some packages like spatie/laravel-sql-commenter uses spatie/invade in v1 version. API is not changed between invade wersions, so just allow installing spatie/invade:^1.0