### PR TITLE
Fix: The interface becomes unresponsive when closing the dialog box w…

### DIFF
--- a/resources/js/components/Modals/ConfirmModal.vue
+++ b/resources/js/components/Modals/ConfirmModal.vue
@@ -59,7 +59,7 @@ const iconBackgroundClass = computed(() => (props.variant ? variants[props.varia
         </div>
       </div>
       <div class="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse sm:gap-x-2 space-y-3 sm:space-y-0">
-        <slot name="confimButton" />
+        <slot name="confirmButton" />
         <slot name="cancelButton" :close="close" />
       </div>
     </DialogPanel>

--- a/resources/js/components/Modals/DeleteFileModal.vue
+++ b/resources/js/components/Modals/DeleteFileModal.vue
@@ -28,7 +28,7 @@ const icon = computed(() => ExclamationCircleIcon)
     variant="danger"
     attribute="deleteFile"
   >
-    <template v-slot:confimButton>
+    <template v-slot:confirmButton>
       <Button class="w-full sm:w-auto" type="button" variant="danger" @click="onConfirm">
         {{ __('Delete') }}
       </Button>

--- a/resources/js/components/Modals/DeleteFolderModal.vue
+++ b/resources/js/components/Modals/DeleteFolderModal.vue
@@ -23,7 +23,7 @@ const icon = computed(() => ExclamationCircleIcon)
     variant="danger"
     attribute="deleteFolder"
   >
-    <template v-slot:confimButton>
+    <template v-slot:confirmButton>
       <Button class="w-full sm:w-auto" type="button" variant="danger" @click="onConfirm">
         {{ __('Delete') }}
       </Button>

--- a/resources/js/stores/browser.ts
+++ b/resources/js/stores/browser.ts
@@ -311,6 +311,7 @@ const useBrowserStore = defineStore('nova-file-manager/browser', {
 
       this.modals = this.modals.filter(_name => _name !== name)
 
+      this.resetError()
       this.fixPortal()
     },
 


### PR DESCRIPTION
Dear owner,

I discovered a bug that made the interface unresponsive to folder change actions and have fixed it.
- Problem: The interface becomes unresponsive when closing the dialog box without resetting the existing error.
- Solution: Call `resetError()` method when close modal.

Before:

https://github.com/oneduo/nova-file-manager/assets/18624860/c8987c16-628e-4b5e-885e-1685bfe5347c

After:

https://github.com/oneduo/nova-file-manager/assets/18624860/bf2c0766-a9a0-4e72-8411-3e29f71ff996

Thank you!