### PR TITLE
Fix: Chunk sending failed and retrying continuously.

### DIFF
--- a/resources/js/stores/browser.ts
+++ b/resources/js/stores/browser.ts
@@ -587,7 +587,10 @@ const useBrowserStore = defineStore('nova-file-manager/browser', {
       this.isUploading = true
 
       const uploader = new Resumable({
+        permanentErrors: [400, 404, 415, 422, 500, 501],
         chunkSize: this.chunkSize,
+        maxChunkRetries: 5,
+        chunkRetryInterval: 1e3,
         simultaneousUploads: 1,
         testChunks: false,
         target: this.url(ENDPOINTS.UPLOAD),


### PR DESCRIPTION
Dear owner,

Currently, the continuous retrying process upon upload failure is consuming server resources, leading to slow response times for users.
- Problem: Continuous retry and slow response
- Solution:
  - Handler status code 422 (ValidationException) -> terminate the upload process and immediately respond to the user.
  - Limit sleep 1 second before retry and max retries is 5 times -> reduce the number of requests to the server.
    
Before:

https://github.com/oneduo/nova-file-manager/assets/18624860/9075f09b-f27c-4d76-9497-1a988d4ae539

After:

https://github.com/oneduo/nova-file-manager/assets/18624860/4fcc337d-032b-4f69-b2d3-7546d05a235f
