### PR TITLE
Load Nova routes in workbench NovaServiceProvider

### DIFF
--- a/workbench/app/Providers/NovaServiceProvider.php
+++ b/workbench/app/Providers/NovaServiceProvider.php
@@ -98,6 +98,8 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
      */
     public function register()
     {
+        parent::register();
+
         FileManager::registerWrapper('repeater', function (FileManager $field) {
             return $field
                 // some options


### PR DESCRIPTION
Call missing parent::register method in workbench NovaServiceProvider.

Closes #460 