### PR TITLE
Change deprecated validation rule contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,19 +46,21 @@ A file manager tool and field for Laravel Nova. Beautifully designed, and custom
 
 ## Table of Contents
 
-- [Getting Started](#getting_started)
+- [Nova File Manager](#nova-file-manager)
+  - [Table of Contents](#table-of-contents)
+  - [Getting Started ](#getting-started-)
     - [Prerequisites](#prerequisites)
     - [Installing](#installing)
     - [Configuration](#configuration)
-- [Usage](#usage)
-- [Configuration](#configuration-file)
-- [Authors](#authors)
-- [Screenshots](#screenshots)
-- [Changelog](#changelog)
-- [Security](#security)
-- [Contributing](#contributing)
-- [Credits](#credits)
-- [License](#license)
+  - [Usage ](#usage-)
+  - [Configuration file ](#configuration-file-)
+  - [Authors ](#authors-)
+  - [Screenshots ](#screenshots-)
+  - [Changelog](#changelog)
+  - [Security](#security)
+  - [Contributing](#contributing)
+  - [Credits](#credits)
+  - [License](#license)
 
 ## Getting Started <a name = "getting_started"></a>
 
@@ -67,6 +69,7 @@ A file manager tool and field for Laravel Nova. Beautifully designed, and custom
 This package requires the following :
 
 - PHP 8.0 or higher
+- Laravel 10 or higher
 - Laravel Nova 4
 
 > **Note** If you plan on using this package with an S3 bucket, be mindful to follow the instructions

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     "php": "^8.0",
     "ext-json": "*",
     "james-heinrich/getid3": "^1.9",
+    "illuminate/contracts": "^10.0 || ^11.0 || ^12.0",
     "laravel/nova": "^4.0 || ^5.0",
     "nova-kit/nova-packages-tool": "^1.3.1 || ^2.0",
     "pion/laravel-chunk-upload": "^1.5",

--- a/src/Contracts/Support/InteractsWithFilesystem.php
+++ b/src/Contracts/Support/InteractsWithFilesystem.php
@@ -94,7 +94,7 @@ interface InteractsWithFilesystem extends ResolvesUrl
     /**
      * Set the validation rules for the upload.
      *
-     * @param  callable|array<int, string|\Illuminate\Validation\Rule|\Illuminate\Contracts\Validation\Rule|callable>|string  ...$rules
+     * @param  callable|array<int, string|\Illuminate\Validation\Rule|\Illuminate\Contracts\Validation\ValidationRule|callable>|string  ...$rules
      * @return $this
      */
     public function uploadRules($rules): static;

--- a/src/Traits/Support/InteractsWithFilesystem.php
+++ b/src/Traits/Support/InteractsWithFilesystem.php
@@ -6,7 +6,7 @@ namespace Oneduo\NovaFileManager\Traits\Support;
 
 use Closure;
 use Illuminate\Contracts\Filesystem\Filesystem;
-use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Oneduo\NovaFileManager\Contracts\Support\InteractsWithFilesystem as InteractsWithFilesystemContract;
 
@@ -346,7 +346,7 @@ trait InteractsWithFilesystem
     /**
      * Set the validation rules for the upload.
      *
-     * @param  callable|array<int, string|\Illuminate\Validation\Rule|\Illuminate\Contracts\Validation\Rule|callable>|string  ...$rules
+     * @param  callable|array<int, string|\Illuminate\Validation\Rule|\Illuminate\Contracts\Validation\ValidationRule|callable>|string  ...$rules
      * @return $this
      */
     public function uploadRules($rules): static
@@ -354,7 +354,7 @@ trait InteractsWithFilesystem
         if ($rules instanceof Closure) {
             $this->uploadRules = [$rules];
         } else {
-            $this->uploadRules = ($rules instanceof Rule || is_string($rules)) ? func_get_args() : $rules;
+            $this->uploadRules = ($rules instanceof ValidationRule || is_string($rules)) ? func_get_args() : $rules;
         }
 
         return $this;


### PR DESCRIPTION
Since Laravel 10, the \Illuminate\Contracts\Validation\Rule contract is deprecated in favor of the \Illuminate\Contracts\Validation\ValidationRule contract.
This PR apply this change and set a minimal requirement for the Laravel version (Laravel 10 or higher).
Consequently, it introduces a breaking change.