### PR TITLE
Feature: add hacky fix to support FileManager's inside native Repeater fields

### DIFF
--- a/src/Http/Requests/BaseRequest.php
+++ b/src/Http/Requests/BaseRequest.php
@@ -62,6 +62,13 @@ class BaseRequest extends NovaRequest
             ? $this->flexibleAvailableFields($resource)
             : $resource->availableFields($this);
 
+        // Flatten repeater fields before searching by attribute
+        $fields = $fields->map(
+            fn($field) => $field instanceof \Laravel\Nova\Fields\Repeater
+                ? $field->repeatables->map->fields($this)->flatten(1)
+                : $field
+        )->flatten(1);
+
         return $fields
             ->whereInstanceOf(FileManager::class)
             ->findFieldByAttribute($this->attribute, function () {

--- a/src/Http/Requests/BaseRequest.php
+++ b/src/Http/Requests/BaseRequest.php
@@ -64,7 +64,7 @@ class BaseRequest extends NovaRequest
 
         // Flatten repeater fields before searching by attribute
         $fields = $fields->map(
-            fn($field) => $field instanceof \Laravel\Nova\Fields\Repeater
+            fn($field) => get_class($field) === 'Laravel\Nova\Fields\Repeater'
                 ? $field->repeatables->map->fields($this)->flatten(1)
                 : $field
         )->flatten(1);


### PR DESCRIPTION
Adds support for FileManager fields inside Nova's native Repeater fields which are for some reason not expanded inside FieldCollections. Without it, the field can not be found, as they appear just as "RepeaterField" in the fields collection.