### PR TITLE
fix: custom filesystem downloads on detail view

### DIFF
--- a/resources/js/@types/index.ts
+++ b/resources/js/@types/index.ts
@@ -43,6 +43,7 @@ export type Config = {
   outdated?: boolean
   perPage?: number
   paginationOptions?: number[]
+  isField: boolean
 }
 
 export type Entity = {

--- a/resources/js/@types/index.ts
+++ b/resources/js/@types/index.ts
@@ -31,6 +31,7 @@ export type BrowserConfig = {
   perPage?: number
   paginationOptions?: number[]
   component?: string
+  isField?: boolean
 }
 
 export type Config = {

--- a/resources/js/components/Cards/FieldCard.vue
+++ b/resources/js/components/Cards/FieldCard.vue
@@ -48,6 +48,7 @@ const preview = (file: Entity) => {
     perPage: 10,
     paginationOptions: undefined,
     component: undefined,
+    isField: true,
   })
   store.setDisk({
     disk: props.field.singleDisk ? 'default' : props.field.value[0].disk,

--- a/resources/js/components/Modals/PreviewModal.vue
+++ b/resources/js/components/Modals/PreviewModal.vue
@@ -151,11 +151,11 @@ const copy = (file: Entity) => {
             <PencilSquareIcon class="w-5 h-5" />
           </IconButton>
 
-          <IconButton ref="buttonRef" @click.self="closePreview" :title="__('NovaFileManager.actions.close')">
+          <IconButton ref="buttonRef" @click="closePreview" :title="__('NovaFileManager.actions.close')">
             <XMarkIcon class="w-5 h-5" />
           </IconButton>
 
-          <IconButton v-if="isField" variant="success" @click="selectThenConfirm">
+          <IconButton v-if="isField && !props.readOnly" variant="success" @click="selectThenConfirm">
             <CheckIcon class="h-5 w-5" />
           </IconButton>
         </div>

--- a/resources/js/fields/DetailField.vue
+++ b/resources/js/fields/DetailField.vue
@@ -13,7 +13,7 @@ interface Props {
   resourceId: string | number
 }
 
-defineProps<Props>()
+const props = defineProps<Props>()
 
 const selected = ref(undefined as Entity | undefined)
 const store = useBrowserStore()
@@ -33,6 +33,7 @@ const copy = (file: Entity) => {
 
 onMounted(() => {
   store.syncDarkMode()
+  store.prepareTool({ ...props.field, isField: true })
 })
 </script>
 

--- a/resources/js/fields/DetailField.vue
+++ b/resources/js/fields/DetailField.vue
@@ -13,7 +13,7 @@ interface Props {
   resourceId: string | number
 }
 
-const props = defineProps<Props>()
+defineProps<Props>()
 
 const selected = ref(undefined as Entity | undefined)
 const store = useBrowserStore()

--- a/resources/js/fields/DetailField.vue
+++ b/resources/js/fields/DetailField.vue
@@ -33,7 +33,6 @@ const copy = (file: Entity) => {
 
 onMounted(() => {
   store.syncDarkMode()
-  store.prepareTool({ ...props.field, isField: true })
 })
 </script>
 

--- a/resources/js/fields/FormField.vue
+++ b/resources/js/fields/FormField.vue
@@ -120,6 +120,7 @@ export default defineComponent({
         perPage: this.currentField.perPage ?? 10,
         paginationOptions: this.currentField.paginationOptions ?? undefined,
         component: this.$inertia?.page?.component,
+        isField: true,
       })
     },
 

--- a/resources/js/stores/browser.ts
+++ b/resources/js/stores/browser.ts
@@ -908,12 +908,13 @@ const useBrowserStore = defineStore('nova-file-manager/browser', {
       cropperOptions,
       perPage,
       paginationOptions,
+      isField = false,
     }: Config) {
       this.init()
       this.clearSelection()
 
       this.limit = undefined
-      this.isField = false
+      this.isField = isField
       this.multiple = true
       this.singleDisk = singleDisk
       this.permissions = permissions

--- a/resources/js/stores/browser.ts
+++ b/resources/js/stores/browser.ts
@@ -805,9 +805,8 @@ const useBrowserStore = defineStore('nova-file-manager/browser', {
       perPage,
       paginationOptions,
       component,
+      isField,
     }: BrowserConfig) {
-      this.isField = true
-
       this.configure({
         initialFiles,
         multiple,
@@ -826,6 +825,7 @@ const useBrowserStore = defineStore('nova-file-manager/browser', {
         perPage,
         paginationOptions,
         component,
+        isField,
       })
 
       this.openModal({ name: BROWSER_MODAL_NAME })

--- a/resources/js/stores/browser.ts
+++ b/resources/js/stores/browser.ts
@@ -849,6 +849,7 @@ const useBrowserStore = defineStore('nova-file-manager/browser', {
       perPage,
       paginationOptions,
       component,
+      isField = false,
     }: BrowserConfig) {
       this.multiple = multiple
       this.limit = limit
@@ -868,6 +869,7 @@ const useBrowserStore = defineStore('nova-file-manager/browser', {
       this.permissions = permissions
       this.disk = undefined
       this.component = component
+      this.isField = isField
     },
 
     closeBrowser() {
@@ -908,13 +910,11 @@ const useBrowserStore = defineStore('nova-file-manager/browser', {
       cropperOptions,
       perPage,
       paginationOptions,
-      isField = false,
     }: Config) {
       this.init()
       this.clearSelection()
 
       this.limit = undefined
-      this.isField = isField
       this.multiple = true
       this.singleDisk = singleDisk
       this.permissions = permissions

--- a/src/Http/Requests/BaseRequest.php
+++ b/src/Http/Requests/BaseRequest.php
@@ -50,6 +50,16 @@ class BaseRequest extends NovaRequest
         return filter_var($this->fieldMode, FILTER_VALIDATE_BOOL) ? $this->resolveField() : $this->resolveTool();
     }
 
+    // Override resource() to use $this->resource instead of $this->route('resource')
+    public function resource()
+    {
+        return tap(once(function () {
+            return Nova::resourceForKey($this->resource);
+        }), static function ($resource) {
+            abort_if(\is_null($resource), 404);
+        });
+    }
+
     public function resolveField(): ?InteractsWithFilesystem
     {
         if (!empty($this->wrapper) && $field = FileManager::forWrapper($this->wrapper)) {


### PR DESCRIPTION
Fields with an overriden filesystem failed on detail view, due to the FileManager not operating in fieldMode and not finding the field.